### PR TITLE
bump version of AWSSDK.CognitoSync to 3.5.0.2 and update version of …

### DIFF
--- a/src/AWSSDK.CognitoSync.SyncManager.csproj
+++ b/src/AWSSDK.CognitoSync.SyncManager.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;net35</TargetFrameworks>
     <DefineConstants>$(DefineConstants);BCL</DefineConstants>
-    <Version>3.5.0.0-beta</Version>
+    <Version>3.5.0.0</Version>
     <PackageId>AWSSDK.CognitoSync.SyncManager</PackageId>
     <Title>AWSSDK - Amazon Cognito Sync Manager</Title>
     <Product>AWSSDK.CognitoSync.SyncManager</Product>
@@ -46,7 +46,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CognitoSync" Version="3.5.0-beta" />
+    <PackageReference Include="AWSSDK.CognitoSync" Version="3.5.0.2" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.97.0" />
   </ItemGroup>
 


### PR DESCRIPTION
…ackage to 3.5.0.0 due to release of AWS SDK for .NET 3.5

## Description
Update package version and dependency versions in line with AWS SDK for .NET v3.5 release

## Motivation and Context
The change is required because the AWS SDK dependency versions do not reflect the lower-bound for the latest AWS .NET SDK release

## Testing
Changed the versions and ran a successful build

## Screenshots (if appropriate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
- [ x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement