### PR TITLE
Use PackageIcon instead of PackageIconUrl

### DIFF
--- a/src/AWSSDK.CognitoSync.SyncManager.csproj
+++ b/src/AWSSDK.CognitoSync.SyncManager.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;net35</TargetFrameworks>
     <DefineConstants>$(DefineConstants);BCL</DefineConstants>
-    <Version>3.5.0.0-beta</Version>
+    <Version>3.5.0.0</Version>
     <PackageId>AWSSDK.CognitoSync.SyncManager</PackageId>
     <Title>AWSSDK - Amazon Cognito Sync Manager</Title>
     <Product>AWSSDK.CognitoSync.SyncManager</Product>
@@ -46,7 +46,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CognitoSync" Version="3.5.0-beta" />
+    <PackageReference Include="AWSSDK.CognitoSync" Version="3.5.0.2" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.97.0" />
   </ItemGroup>
 

--- a/src/AWSSDK.CognitoSync.SyncManager.csproj
+++ b/src/AWSSDK.CognitoSync.SyncManager.csproj
@@ -12,8 +12,7 @@
     <PackageTags>>AWS;Amazon;cloud;CognitoSync;CognitoSyncManager;aws-sdk-v3</PackageTags>
     <PackageProjectUrl>https://github.com/aws/amazon-cognito-sync-manager-net</PackageProjectUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <!-- Replace with PackageIcon when Visual Studio supports it. -->
-    <PackageIconUrl>https://sdk-for-net.amazonwebservices.com/images/AWSLogo128x128.png</PackageIconUrl>
+    <PackageIcon>icon.png</PackageIcon>
     <RepositoryUrl>https://github.com/aws/amazon-cognito-sync-manager-net</RepositoryUrl>
     <Company>Amazon Web Services</Company>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use PackageIcon instead of PackageIconUrl which is being deprecated

## Motivation and Context
https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5048

## Testing
build/pack working successfully 

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement