### PR TITLE
chore: relax stale issue timings

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -29,8 +29,8 @@ jobs:
         closed-for-staleness-label: closed-for-staleness
 
         # Issue timing
-        days-before-stale: 5
-        days-before-close: 2
+        days-before-stale: 10
+        days-before-close: 4
         days-before-ancient: 36500
 
         # If you don't want to mark a issue as being ancient based on a


### PR DESCRIPTION
We received customer feedback that our stale issue timings are too tight. This doubles what we had previously.
